### PR TITLE
remove cocoapods from CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,9 @@ jobs:
       - checkout
 
       # Install CocoaPods
-      - run:
-          name: Install CocoaPods
-          command: pod install
+      #- run:
+          #name: Install CocoaPods
+          #command: pod install
 
       # Build the app and run tests
       - run:


### PR DESCRIPTION
Commenting out cocoapods install for circleCI build. Pods are already available in the repo.